### PR TITLE
Ensure map renders when easyPrint plugin is missing

### DIFF
--- a/app.py
+++ b/app.py
@@ -63,6 +63,10 @@ class HiResPrint(MacroElement):
     {% macro script(this, kwargs) %}
     (function(){
       var map = {{this._parent.get_name()}};
+      if (!(window.L && L.easyPrint)) {
+        console.warn('easyPrint plugin not loaded; export disabled');
+        return;
+      }
       var originalSize;
 
       function resizeMap(factor){
@@ -192,12 +196,14 @@ def geocode_address(address):
 if search_button:
     with st.spinner("Finding location..."):
         lat, lon = geocode_address(address_input)
-        if lat and lon:
+        if lat is not None and lon is not None:
             st.session_state.address_coords = (lat, lon)
         else:
-            st.error("Could not find address. Reverting to last known location.")
+            st.error("Could not find address. Showing last known location.")
+            if "address_coords" not in st.session_state:
+                st.session_state.address_coords = (33.9239, -118.2620)
 
-lat, lon = st.session_state.address_coords
+lat, lon = st.session_state.get("address_coords", (33.9239, -118.2620))
 
 left, right = st.columns([2.2, 1])
 


### PR DESCRIPTION
## Summary
- Skip HiResPrint control if the Leaflet easyPrint plugin fails to load
- Prevent missing export dependency from blocking map rendering

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689a0c65803083308999222080c6f95a